### PR TITLE
Update composer.json to support illuminate packages up to version 12.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "version": "2.0.0",
     "require": {
         "php": "^7.3|^8.0",
-        "illuminate/console": "^8.0|^9.0|^10.0|^11.0",
-        "illuminate/support": "^8.0|^9.0|^10.0|^11.0"
+        "illuminate/console": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This pull request includes a minor update to the `composer.json` file to expand the compatibility of the package with newer versions of dependencies.

Dependency updates:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L8-R9): Updated the version constraints for `illuminate/console` and `illuminate/support` to include compatibility with version 12.0.