### PR TITLE
Add template option to command

### DIFF
--- a/src/Commands/GenerateDocsCommand.php
+++ b/src/Commands/GenerateDocsCommand.php
@@ -19,7 +19,8 @@ class GenerateDocsCommand extends Command
                             {--max-tokens= : Maximum tokens for API calls (default: from config or 10000)}
                             {--extensions=* : File extensions to process (default: from config or php, yaml, yml)}
                             {--skip=* : Subdirectories to skip (default: from config or vendor/, node_modules/, tests/, cache/)}
-                            {--api-provider= : API provider to use (default: from config or openai)}';
+                            {--api-provider= : API provider to use (default: from config or openai)}
+                            {--template= : Markdown template to use (absolute path to .md file) (default: default-prompt.md from library)'};
 
     /**
      * The console command description.
@@ -98,11 +99,16 @@ class GenerateDocsCommand extends Command
         }, $sourceDirs);
         
         $outputDir = base_path($outputDir);
+
+        $template = $this->option('template');
         
         $this->info('Starting documentation generation...');
         $this->info('Source directories: ' . implode(', ', $sourceDirs));
         $this->info('Output directory: ' . $outputDir);
         $this->info('API provider: ' . $apiProvider);
+        if(!empty($template)){
+            $this->info('Prompt template: ' . $template);
+        }
         
         try {
             $generator = new Docudoodle(
@@ -115,7 +121,8 @@ class GenerateDocsCommand extends Command
                 $skipSubdirs,
                 $apiProvider,
                 $ollamaHost,
-                $ollamaPort
+                $ollamaPort,
+                $template
             );
             
             $generator->generate();


### PR DESCRIPTION
I'm not sure if this fits your idea, but I made it such that template can be passed.

Maybe you could make few templates and make it selectable?

```php
use function Laravel\Prompts\select;
$template       = select(
            label: 'Which template you would like to use?',
            options: ['default', 'simple', 'advanced', 'detailed','custom'],
            scroll: 10
);
```
And if custom, then resolve the relative path to file user provided?
This is using the [Laravel\Prompts](https://github.com/laravel/prompts) package.