### PR TITLE
feat: Add Azure OpenAI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ If you want to see what the output of some documentation looks like, check out t
 ## Features
 
 - **Automatic Documentation Generation**: Effortlessly generates documentation for PHP files by analyzing their content.
-- **Flexible AI Integration**: Choose between OpenAI's powerful cloud API, Claude API, Google's Gemini API, or run locally with Ollama models for complete privacy.
+- **Flexible AI Integration**: Choose between OpenAI's powerful cloud API, Azure OpenAI, Claude API, Google's Gemini API, or run locally with Ollama models for complete privacy.
 - **Ollama Support**: Generate documentation completely offline using your own local Ollama models - perfect for private codebases or when you need to work without an internet connection.
+- **Azure OpenAI Support**: Use Microsoft's Azure OpenAI service for documentation generation with enterprise-grade security and compliance.
 - **Customizable**: Easily configure source directories, output folders, and other settings to match your workflow.
 - **Command-Line Interface**: Includes a simple command-line script for quick documentation generation.
 
@@ -67,6 +68,15 @@ Set your Claude API key here or in your `.env` file as `CLAUDE_API_KEY`.
 ```
 Set your Gemini API key here or in your `.env` file as `GEMINI_API_KEY`.
 
+### Azure OpenAI Settings
+```php
+'azure_endpoint' => env('AZURE_OPENAI_ENDPOINT', ''),
+'azure_api_key' => env('AZURE_OPENAI_API_KEY', ''),
+'azure_deployment' => env('AZURE_OPENAI_DEPLOYMENT', ''),
+'azure_api_version' => env('AZURE_OPENAI_API_VERSION', '2023-05-15'),
+```
+Configure Azure OpenAI integration. You need to provide the endpoint URL, API key, deployment ID, and optionally the API version if using Azure as your API provider.
+
 ### Model Selection
 ```php
 'default_model' => env('DOCUDOODLE_MODEL', 'gpt-4o-mini'),
@@ -77,7 +87,7 @@ Choose which model to use. The default is `gpt-4o-mini` for OpenAI, but you can 
 ```php
 'default_api_provider' => env('DOCUDOODLE_API_PROVIDER', 'openai'),
 ```
-Choose which API provider to use: 'openai' for cloud-based generation, 'claude' for Claude API, 'gemini' for Gemini API, or 'ollama' for local generation. Set in your `.env` file with `DOCUDOODLE_API_PROVIDER`.
+Choose which API provider to use: 'openai' for cloud-based generation, 'azure' for Azure OpenAI, 'claude' for Claude API, 'gemini' for Gemini API, or 'ollama' for local generation. Set in your `.env` file with `DOCUDOODLE_API_PROVIDER`.
 
 ### Ollama Configuration
 ```php
@@ -146,6 +156,28 @@ Then specify the custom template path when initializing Docudoodle:
 $docudoodle = new Docudoodle(
     promptTemplate: '/path/to/your/custom-template.md'
 );
+```
+
+## Using Azure OpenAI
+
+To generate documentation using Azure OpenAI:
+
+1. Set up your Azure configuration in the `.env` file:
+```
+AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
+AZURE_OPENAI_API_KEY=your-api-key
+AZURE_OPENAI_DEPLOYMENT=your-deployment-id
+DOCUDOODLE_API_PROVIDER=azure
+```
+
+2. Run the command:
+```
+php artisan docudoodle:generate
+```
+
+You can also specify Azure parameters directly in the command:
+```
+php artisan docudoodle:generate --api-provider=azure --azure-endpoint=https://your-resource.openai.azure.com --azure-deployment=your-deployment
 ```
 
 ## Running Tests

--- a/config/docudoodle.php
+++ b/config/docudoodle.php
@@ -88,11 +88,29 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Azure OpenAI Settings
+    |--------------------------------------------------------------------------
+    |
+    | Settings for Azure OpenAI integration.
+    |
+    | endpoint: Your Azure OpenAI resource endpoint
+    | api_key: Your Azure OpenAI API key
+    | deployment: Your Azure OpenAI deployment ID
+    | api_version: Azure OpenAI API version (default: 2023-05-15)
+    |
+    */
+    'azure_endpoint' => env('AZURE_OPENAI_ENDPOINT', ''),
+    'azure_api_key' => env('AZURE_OPENAI_API_KEY', ''),
+    'azure_deployment' => env('AZURE_OPENAI_DEPLOYMENT', ''),
+    'azure_api_version' => env('AZURE_OPENAI_API_VERSION', '2023-05-15'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Default API Provider
     |--------------------------------------------------------------------------
     |
     | The default API provider to use for generating documentation.
-    | Supported values: 'openai', 'ollama', 'claude', 'gemini'
+    | Supported values: 'openai', 'ollama', 'claude', 'gemini', 'azure'
     |
     */
     'default_api_provider' => env('DOCUDOODLE_API_PROVIDER', 'openai'),

--- a/tests/AzureOpenAITest.php
+++ b/tests/AzureOpenAITest.php
@@ -1,0 +1,67 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Docudoodle\Docudoodle;
+
+class AzureOpenAITest extends TestCase
+{
+    public function testAzureOpenAIIntegrationConstructorParameters()
+    {
+        // Arrange
+        $azureEndpoint = 'https://test-resource.openai.azure.com';
+        $azureDeployment = 'test-deployment';
+        $azureApiVersion = '2023-05-15';
+        
+        // Act
+        $docudoodle = new Docudoodle(
+            openaiApiKey: 'test-key',
+            apiProvider: 'azure',
+            azureEndpoint: $azureEndpoint,
+            azureDeployment: $azureDeployment,
+            azureApiVersion: $azureApiVersion
+        );
+        
+        // Assert - if the constructor doesn't throw any exceptions, we can assume it works
+        $this->assertIsObject($docudoodle);
+    }
+
+    public function testAzureConfigurationValuesAreUsedProperly()
+    {
+        // This is a reflection-based test to check that the properties are set correctly
+        
+        // Arrange
+        $azureEndpoint = 'https://test-resource.openai.azure.com';
+        $azureDeployment = 'test-deployment';
+        $azureApiVersion = '2023-07-01'; // Custom version
+        
+        // Act
+        $docudoodle = new Docudoodle(
+            openaiApiKey: 'test-key',
+            apiProvider: 'azure',
+            azureEndpoint: $azureEndpoint,
+            azureDeployment: $azureDeployment,
+            azureApiVersion: $azureApiVersion
+        );
+        
+        // Use reflection to access private properties
+        $reflector = new ReflectionClass($docudoodle);
+        
+        $endpointProperty = $reflector->getProperty('azureEndpoint');
+        $endpointProperty->setAccessible(true);
+        
+        $deploymentProperty = $reflector->getProperty('azureDeployment');
+        $deploymentProperty->setAccessible(true);
+        
+        $versionProperty = $reflector->getProperty('azureApiVersion');
+        $versionProperty->setAccessible(true);
+        
+        $providerProperty = $reflector->getProperty('apiProvider');
+        $providerProperty->setAccessible(true);
+        
+        // Assert
+        $this->assertEquals($azureEndpoint, $endpointProperty->getValue($docudoodle));
+        $this->assertEquals($azureDeployment, $deploymentProperty->getValue($docudoodle));
+        $this->assertEquals($azureApiVersion, $versionProperty->getValue($docudoodle));
+        $this->assertEquals('azure', $providerProperty->getValue($docudoodle));
+    }
+} 


### PR DESCRIPTION
Hi, I currently work in an enterprise environment where the use of 'public' LLMs with our code is restricted, so I've added support for Azure's OpenAI service which will allow Docudoodle to be used.

- Implemented Azure OpenAI documentation generation in Docudoodle class.
- Modified GenerateDocsCommand to accept Azure-specific parameters.
- Updated README.md to include Azure OpenAI as a supported API provider.
- Enhanced configuration options in docudoodle.php for Azure OpenAI settings.
- Added unit tests for Azure OpenAI integration.