### PR TITLE
Update illuminate dependencies to include version 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
 	"version": "2.2.0",
 	"require": {
 		"php": "^7.3|^8.0",
-		"illuminate/console": "^8.0|^9.0|^10.0|^11.0|^12.0",
-		"illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0"
+		"illuminate/console": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+		"illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
This pull request makes a small update to the package dependencies in `composer.json` to add support for Laravel 13 by allowing version 13 of the `illuminate/console` and `illuminate/support` packages.